### PR TITLE
[FEAT] 메인 페이지 게시글 리스트 적용 및 PostListForm 수정

### DIFF
--- a/src/app/channel/[channel]/[item]/page.tsx
+++ b/src/app/channel/[channel]/[item]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import SubmitButton from "@/components/button/SubmitButton";
-import {PostListForm} from "@/components/post/PostListForm";
 import {pathDivided} from "@/util/PathDivider";
 import Link from "next/link";
 import {usePathname} from "next/navigation";
@@ -24,7 +23,8 @@ export default function Channel() {
     return (
         <div>
             <div className="my-5">
-                <PostListForm channelItems={channelItemData}/>
+                {/*TODO: 다른 PR 에서 새로운 Form 작성 예정*/}
+                {/*<PostListForm channelItems={channelItemData}/>*/}
             </div>
             <Link href={`/channel/${channel}/${channelItemData}/write`}>
                 <SubmitButton buttonName="글쓰기"/>

--- a/src/app/channel/[channel]/[item]/page.tsx
+++ b/src/app/channel/[channel]/[item]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import SubmitButton from "@/components/button/SubmitButton";
-import { PostListForm } from "@/components/post/PostListForm";
+import { PostListMainForm } from "@/components/post/PostListMainForm";
 import { ChannelItemData } from "@/lib/types/ChannerType";
 import { pathDivided } from "@/util/PathDivider";
 import Link from "next/link";
@@ -16,8 +16,8 @@ export default function Channel() {
     return (
         <div>
             <div className="my-5">
-                // TODO: 새로운 폼 적용 필요
-                <PostListForm channelItem={channelItemData} />
+                 {/*TODO: 새로운 폼 적용 필요*/}
+                <PostListMainForm channelItem={channelItemData} />
             </div>
             <Link href={`/channel/${channel}/${item4}/write`}>
                 <SubmitButton buttonName="글쓰기" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,21 +4,21 @@
 
 @font-face {
     font-family: "LineSeedFont";
-    src: url("/fonts/LINESeedKR-Bd.ttf") format("truetype");
+    src: url("/public/fonts/LINESeedKR-Bd.ttf") format("truetype");
     font-weight: 700;
     font-style: normal;
 }
 
 @font-face {
     font-family: "LineSeedFont";
-    src: url("/fonts/LINESeedKR-Rg.ttf") format("truetype");
+    src: url("/public/fonts/LINESeedKR-Rg.ttf") format("truetype");
     font-weight: 400;
     font-style: normal;
 }
 
 @font-face {
     font-family: "LineSeedFont";
-    src: url("/fonts/LINESeedKR-Th.ttf") format("truetype");
+    src: url("/public/fonts/LINESeedKR-Th.ttf") format("truetype");
     font-weight: 100;
     font-style: normal;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,44 @@
+'use client'
+
+import {Suspense} from 'react'
+import {PostListMainForm} from "@/components/post/PostListMainForm";
+
+// 채널 아이템 데이터 인터페이스
+interface ChannelItemData {
+    token: string
+}
+
 export default function Home() {
-  return <div></div>;
+    // TODO: 메인 페이지에 보여줄 채널 아이템 로직 추가 예정 - 현재는 로컬 DB 더미 데이터 사용
+    // .env 에서 메인 페이지에 띄울 채널 아이템
+    /*const channelItemNums = [1, 2, 3, 4, 5, 6]; // 필요한 채널 번호 배열
+    const mainChannels: ChannelItemData[] = channelItemNums.map((num) => {
+        const envKey = `NEXT_PUBLIC_MAIN_CI_TOKEN${num}`;
+        return { token: getEnvVariable(envKey) };
+    });*/
+    const mainChannels: ChannelItemData[] = [
+        {token: "d15f898c46f67a0"},
+        {token: "d15f898c46f67a0"},
+        {token: "d15f898c46f67a0"},
+        {token: "d15f898c46f67a0"},
+        {token: "d15f898c46f67a0"},
+        {token: "d15f898c46f67a0"},
+        {token: "d15f898c46f67a0"}
+    ]
+
+    return (
+        <main className="container mx-auto p-4 bg-white min-h-screen">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 p-4">
+                {/* 반응형 col 기본값 : 모바일(1col), 태블릿(2col), 데스크탑(3col)*/}
+                {mainChannels.map((channel) => (
+                    <Suspense
+                        key={channel.token}
+                        fallback={<div className="p-4 bg-gray-100 rounded-lg">로딩 중...</div>}
+                    >
+                        <PostListMainForm channelItem={{token: channel.token}}/>
+                    </Suspense>
+                ))}
+            </div>
+        </main>
+    )
 }

--- a/src/app/post/list/preview/[token]/page.tsx
+++ b/src/app/post/list/preview/[token]/page.tsx
@@ -6,27 +6,26 @@ import {PostListForm} from "@/components/post/PostListForm"
 import {pathDivided} from "@/util/PathDivider"
 
 interface ChannelItemData {
-    token: string
+    token: string;
 }
 
 export default function PostList() {
     const pathname = usePathname()
-    const [channelItemData, setChannelItemData] = useState<ChannelItemData[]>([])
+    const [channelItemData, setChannelItemData] = useState<ChannelItemData | null>(null)
     const [loading, setLoading] = useState(true)
 
     useEffect(() => {
-        if (!pathname) return
+        if (!pathname) return;
 
         const {item5} = pathDivided(pathname)
-        setChannelItemData([{
-            token: item5
-        }])
-        setLoading(false)
+
+        setChannelItemData({token : item5});
+        setLoading(false);
     }, [pathname])
 
-    if (!pathname || loading) {
+    if (!pathname || loading || !channelItemData) {
         return <div className="p-4">로딩 중...</div>
     }
 
-    return <PostListForm channelItems={channelItemData}/>
+    return <PostListForm channelItem={channelItemData}/>
 }

--- a/src/app/post/list/preview/[token]/page.tsx
+++ b/src/app/post/list/preview/[token]/page.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import { PostListForm } from "@/components/post/PostListForm";
+import { PostListMainForm } from "@/components/post/PostListMainForm";
 import { ChannelItemData } from "@/lib/types/ChannerType";
 import { pathDivided } from "@/util/PathDivider";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-
-interface ChannelItemData {
-    token: string;
-}
 
 export default function PostList() {
     const pathname = usePathname();
@@ -31,5 +27,5 @@ export default function PostList() {
         return <div className="p-4">로딩 중...</div>;
     }
 
-    return <PostListForm channelItem={channelItemData} />;
+    return <PostListMainForm channelItem={channelItemData} />;
 }

--- a/src/components/post/PostListForm.tsx
+++ b/src/components/post/PostListForm.tsx
@@ -14,15 +14,15 @@ interface ChannelItemData {
     token: string;
 }
 
-export function PostListForm({channelItems}: { channelItems: ChannelItemData[] }) {
+export function PostListForm({channelItem}: { channelItem: ChannelItemData }) {
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 p-4">
-            {channelItems.map((channelItem) => (
+            {(
                 <ChannelItemSection
                     key={channelItem.token}
                     token={channelItem.token}
                 />
-            ))}
+            )}
         </div>
     );
 }

--- a/src/components/post/PostListMainForm.tsx
+++ b/src/components/post/PostListMainForm.tsx
@@ -1,52 +1,49 @@
 "use client";
 
 import ErrorDisplay from "@/components/ErrorDisplay";
-import { ApiResponse } from "@/lib/ApiResponse";
-import { PostListResponse } from "@/lib/response/PostResponse";
-import { ChannelItemData } from "@/lib/types/ChannerType";
-import {
-    ClockIcon,
-    DocumentIcon,
-    EyeIcon,
-    HeartIcon,
-} from "@heroicons/react/24/outline";
-import { Skeleton } from "@mui/material";
-import { Post } from "@prisma/client";
-import { formatDistanceToNow } from "date-fns";
-import { ko } from "date-fns/locale";
+import {ApiResponse} from "@/lib/ApiResponse";
+import {PostListResponse} from "@/lib/response/PostResponse";
+import {ChannelItemData} from "@/lib/types/ChannerType";
+import {ClockIcon, DocumentIcon, EyeIcon, HeartIcon,} from "@heroicons/react/24/outline";
+import {Skeleton} from "@mui/material";
+import {Post} from "@prisma/client";
+import {formatDistanceToNow} from "date-fns";
+import {ko} from "date-fns/locale";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 
-export function PostListForm({
-    channelItem,
-}: {
+export function PostListMainForm({
+                                 channelItem,
+                             }: {
     channelItem: ChannelItemData;
 }) {
     return (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 p-4">
-            <ChannelItemSection
-                key={channelItem.token}
-                token={channelItem.token}
-            />
-        </div>
+        <ChannelItemSection
+            token={channelItem.token}
+        />
     );
 }
 
-function ChannelItemSection({ token }: { token: string }) {
+function ChannelItemSection({token}: { token: string }) {
     const [posts, setPosts] = useState<Post[]>([]);
     const [channelItemName, setChannelItemName] = useState("");
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const SKELETON_ITEMS = Array(3).fill(null); // TODO: 메인 화면 설정 시 검토 필요
+    const SKELETON_ITEMS = Array(3).fill(null);
 
     useEffect(() => {
+        console.log("fetchPreviewData called with token:", token); // 로그 추가
+
         const fetchPreviewData = async () => {
+            console.log("ChannelItemSection useEffect", token);
+
             try {
                 if (!token) {
                     throw new Error("유효하지 않은 게시판 토큰");
                 }
 
                 const resPost = await fetch(`/api/post/list/preview/${token}`);
+
                 if (!resPost.ok) {
                     throw new Error(`HTTP ${resPost.status}`);
                 }
@@ -65,7 +62,7 @@ function ChannelItemSection({ token }: { token: string }) {
                 const resChannelItemName = await fetch(
                     `/api/channel/item/name/${token}`
                 );
-                const { data } = await resChannelItemName.json();
+                const {data} = await resChannelItemName.json();
                 if (!data) {
                     throw new Error("게시판 이름 불러오기 실패");
                 }
@@ -110,7 +107,7 @@ function ChannelItemSection({ token }: { token: string }) {
                 />
             ) : posts.length === 0 ? (
                 <div className="text-center py-3">
-                    <DocumentIcon className="w-7 h-7 mx-auto text-gray-400" />
+                    <DocumentIcon className="w-7 h-7 mx-auto text-gray-400"/>
                     <p className="text-gray-500 text-xs mt-1.5">
                         게시글이 없습니다
                     </p>
@@ -131,7 +128,7 @@ function ChannelItemSection({ token }: { token: string }) {
                                     <div className="flex gap-1.5">
                                         {/* 조회수 영역 */}
                                         <div className="flex items-center gap-1 text-gray-500">
-                                            <EyeIcon className="w-3.5 h-3.5" />
+                                            <EyeIcon className="w-3.5 h-3.5"/>
                                             <span className="text-[11px]">
                                                 {post.views}
                                             </span>
@@ -139,7 +136,7 @@ function ChannelItemSection({ token }: { token: string }) {
 
                                         {/* 좋아요 영역 */}
                                         <div className="flex items-center gap-1 text-gray-500">
-                                            <HeartIcon className="w-3.5 h-3.5" />
+                                            <HeartIcon className="w-3.5 h-3.5"/>
                                             <span className="text-[11px]">
                                                 {post.likes}
                                             </span>
@@ -147,7 +144,7 @@ function ChannelItemSection({ token }: { token: string }) {
 
                                         {/* 시간 표시 영역 */}
                                         <div className="flex items-center gap-1 text-gray-500">
-                                            <ClockIcon className="w-3.5 h-3.5" />
+                                            <ClockIcon className="w-3.5 h-3.5"/>
                                             <span className="text-[11px]">
                                                 {formatDistanceToNow(
                                                     new Date(post.createdAt),

--- a/src/lib/repository/ChannelItemRepository.ts
+++ b/src/lib/repository/ChannelItemRepository.ts
@@ -7,7 +7,6 @@ export class ChannelItemRepository {
         this.query = new ChannelItemQuery();
     }
 
-
     async findChannelItemName(token: string){
         return this.query.findChannelItemNameByToken(token);
     }

--- a/src/util/GetEnvVariable.ts
+++ b/src/util/GetEnvVariable.ts
@@ -1,0 +1,9 @@
+// 환경 변수 유틸리티 함수
+export function getEnvVariable(key: string): string {
+    const value = process.env[key];
+    if (!value) {
+        console.log(`환경 변수 ${key}가 정의되지 않았습니다.`);
+        return ""; // 기본값 설정
+    }
+    return value;
+}


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)

### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
---
- 해당하는 PR 타입 중 자세한 타입 체크해주세요.
- FEAT
  - [x] 기능 추가
  - [ ] 기능 삭제
  - [ ] 테스트 코드 추가
- BUG
  - [ ] 버그 수정
- HOTFIX
  - [ ] 긴급 수정
- DOC
  - [ ] 문서 수정
- REFACTOR
  - [x] 리팩토링
  - [ ] 스타일 수정
- DEPLOY
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
  - [ ] 개발 환경 세팅
---
### 참고 사항
- 관련 이슈 번호: #93 
- Home page.tsx 의 12-18 라인을 19-27 대신 적용하면 token 적용에 에러가 생깁니다
    - 해결 방법을 아시는 분 코멘트 남겨주세요..
    - ```
       NEXT_PUBLIC_MAIN_CI_TOKEN1=d15f898c46f67a0
      ```
---
### 변경 사항
- PostListForm에서 배열을 삭제하고 Home 의 page.tsx 에서 배열 형태로 부르는 형태로 수정하였습니다.
    - 여기서 Channel 에 적용할 PostListMainForm 을 PostListChannelForm 으로 생성은 하였으나 혹시 지금처럼 PostListMainForm 에서 배열이 사라졌다면 PostListChannelForm 가 필요없을까요? @km2535 
---
### 스크린샷 / 데모 링크
- 스크린샷이나 데모 링크를 첨부하여 변경 내용을 시각적으로 보여주세요.
- Description
  - 메인 페이지
  <img src ="https://github.com/user-attachments/assets/a441df4e-0236-4ed7-9a53-9f7260229ea4" width="500" height="300" />

  - 채널 페이지
  <img src ="https://github.com/user-attachments/assets/5a26090f-c9e9-4d74-b3c6-29ec1333adbd" width="500" height="300" />

